### PR TITLE
FISH-326 Refactor Deployment Profiles

### DIFF
--- a/api/payara-api/pom.xml
+++ b/api/payara-api/pom.xml
@@ -139,13 +139,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
             </plugin>
-            
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -816,13 +816,6 @@
                     <flattenMode>bom</flattenMode>
                 </configuration>
             </plugin>
-            
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -56,6 +56,29 @@
         <module>payara-api</module>
         <module>payara-bom</module>
     </modules>
-    
 
+    <properties>
+        <deploy.skip>false</deploy.skip>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+	    </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <inherited>false</inherited>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/distributions/payara-ml/pom.xml
+++ b/appserver/distributions/payara-ml/pom.xml
@@ -100,12 +100,6 @@
                     </pomElements>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -127,19 +121,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/distributions/payara-web-ml/pom.xml
+++ b/appserver/distributions/payara-web-ml/pom.xml
@@ -102,12 +102,6 @@
                     </pomElements>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -129,19 +123,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/distributions/payara-web/pom.xml
+++ b/appserver/distributions/payara-web/pom.xml
@@ -103,12 +103,6 @@
                     </pomElements>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -130,19 +124,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/distributions/payara/pom.xml
+++ b/appserver/distributions/payara/pom.xml
@@ -103,13 +103,6 @@
                     </pomElements>
                 </configuration>
             </plugin>
-            
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -132,19 +125,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -77,6 +77,7 @@
     </developers>
 
     <properties>
+        <deploy.skip>false</deploy.skip>
         <stage.dir.name>stage</stage.dir.name>
         <stage.dir>${project.build.directory}/${stage.dir.name}</stage.dir>
         <temp.dir>${project.build.directory}/dependency</temp.dir>
@@ -206,9 +207,26 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <inherited>false</inherited>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
+
+        <!-- Don't deploy any distributions if only the internals are being deployed -->
+        <profile>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+            </properties>
+        </profile>
 
         <!-- Default build profile -->
         <profile>

--- a/appserver/ejb/ejb-http-remoting/client/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/client/pom.xml
@@ -59,6 +59,10 @@
         which will be sent via HTTP to Payara.
     </description>
 
+    <properties>
+        <deploy.skip>false</deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -123,29 +127,16 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
             </plugin>
-            
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <!-- Don't deploy any distributions if only the internals are being deployed -->
         <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+            </properties>
         </profile>
     </profiles>
 

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -51,8 +51,13 @@
         <version>5.2020.5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+
     <artifactId>payara-embedded-all</artifactId>
     <name>Embedded Payara All-In-One</name>
+
+    <properties>
+        <deploy.skip>false</deploy.skip>
+    </properties>
 
     <build>
         <defaultGoal>install</defaultGoal>
@@ -111,12 +116,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -469,17 +468,10 @@
             </build>
         </profile>
         <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/appserver/extras/embedded/pom.xml
+++ b/appserver/extras/embedded/pom.xml
@@ -53,9 +53,19 @@
     <artifactId>embedded</artifactId>
     <packaging>pom</packaging>
     <name>Payara Embedded modules</name>
+
     <modules>
         <module>all</module>
         <module>web</module>
         <module>tests</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -55,6 +55,10 @@
     <artifactId>payara-embedded-web</artifactId>
     <name>Embedded Payara Web</name>
 
+    <properties>
+        <deploy.skip>false</deploy.skip>
+    </properties>
+
     <build>
         <defaultGoal>install</defaultGoal>
         <plugins>
@@ -111,12 +115,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -372,19 +370,6 @@
 
     <profiles>
         <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>jdk8</id>
             <activation>
                 <jdk>[1.8,)</jdk>
@@ -426,6 +411,12 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/appserver/extras/javaee/pom.xml
+++ b/appserver/extras/javaee/pom.xml
@@ -57,4 +57,15 @@
         <module>manifest-jar</module>
         <module>dist-frag</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -53,6 +53,7 @@
 
     <properties>
         <product.name>Payara Micro</product.name>
+        <deploy.skip>false</deploy.skip>
     </properties>
 
     <build>
@@ -123,12 +124,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -524,17 +519,10 @@
             </properties>
         </profile>
         <profile>
-            <id>deployinternals</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <id>deploy-internals</id>
+            <properties>
+                <deploy.skip>true</deploy.skip>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -63,6 +63,18 @@
         <module>payara-micro</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <inherited>false</inherited>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>embedded</id>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -77,6 +77,7 @@
     </developers>
 
     <properties>
+        <deploy.skip>true</deploy.skip>
         <stage.dir.name>stage</stage.dir.name>
         <stage.dir>${project.build.directory}/${stage.dir.name}</stage.dir>
         <temp.dir>${project.build.directory}/dependency</temp.dir>
@@ -167,12 +168,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -117,8 +117,6 @@
         <maven.build.helper.plugin.version>3.0.0</maven.build.helper.plugin.version>
         <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
 
-        <deploy.skip>true</deploy.skip>
-
         <!-- Servlet -->
         <!-- Requires JDK8u161 or above-->
         <grizzly.npn.version>1.9.payara-p1</grizzly.npn.version>
@@ -992,12 +990,6 @@ Parent is ${project.parent}</echo>
     </dependencyManagement>
 
     <profiles>
-        <profile>
-            <id>deployinternals</id>
-            <properties>
-                <deploy.skip>false</deploy.skip>
-            </properties>
-        </profile>
         <profile>
             <id>ci</id>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <javase.version>1.8</javase.version>
-        <deploy.skip>false</deploy.skip>
+        <deploy.skip>true</deploy.skip>
+
         <!-- BOM-referenced versions -->
         <jakartaee.api.version>8.0.0</jakartaee.api.version>
         <servlet-api.version>4.0.2</servlet-api.version>
@@ -342,10 +343,15 @@
         </profile>
 
         <profile>
-            <id>deployinternals</id>
+            <id>deploy-internals</id>
+
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+
+            <properties>
+                <deploy.skip>false</deploy.skip>
+            </properties>
 
             <distributionManagement>
                 <repository>
@@ -353,31 +359,12 @@
                     <url>https://nexus.payara.fish/repository/payara-artifacts/</url>
                 </repository>
             </distributionManagement>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>false</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
     </profiles>
 
     <build>
         <defaultGoal>install</defaultGoal>
-        <plugins>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
 
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
- Rename 'deployinternals' profile to 'deploy-internals'
- Reuse 'deploy.skip' property, and remove most overrides that ignore
this property
- Remove all artifacts except for subgroups of 'fish.payara.server' from
the 'deploy-internals' profile

Signed-off-by: Matthew Gill <matthew.gill@live.co.uk>

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 1.8_212 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
